### PR TITLE
The proper CLI foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,37 @@ cd ai-toolbox-cockpit
 pipx install --editable .
 ```
 
+## Command-line interface
+
+Running `ai-toolbox-cockpit` without arguments opens the Textual interface.
+
+For automated pipelines, scripts, and diagnostics, command-line mode provides non-interactive reports and commands without launching the full TUI:
+
+### Static catalogue reports
+
+Static reports inspect application metadata, configuration, platforms, toolboxes, and models without launching the TUI, contacting containers or engines, accessing the network, or starting models:
+
+```bash
+# Human-readable summary
+ai-toolbox-cockpit info
+
+# Full catalogue details in human-readable format
+ai-toolbox-cockpit info --full
+
+# Machine-readable JSON output for pipelines
+ai-toolbox-cockpit info --output json
+ai-toolbox-cockpit info --full --output json
+```
+
+- `--output text|json`: selects the output format; `text` is the default. JSON writes a single structured document to `stdout`, including `schema_version`, `command`, `ok`, and `data`; errors are structured JSON on `stderr`.
+- `--full`: includes all static catalogue fields, runtime profiles, backend-specific configurations, and launch recommendations.
+- Supported aliases: `-info` and `-fullinfo` (e.g. `ai-toolbox-cockpit -fullinfo --output json`).
+- Both `-h`, `-help`, and `--help` display the command reference.
+
+### Server management (reserved)
+
+The `server plan|start`, `server status`, `server logs`, and `server stop` command namespace is reserved for backend-owned CLI workflows. In this release, each server command reports that it is not yet implemented and exits safely with code `3` without changing runtime state.
+
 ## Runtime requirements
 
 AI Toolbox Cockpit supports either of these interactive-container combinations:
@@ -104,7 +135,7 @@ The vLLM catalog imports the toolbox's model launch recipe rather than replacing
 
 Purpose-built llama.cpp forks can declare a validated `recommended_use` profile in `toolboxes.json`. The server view uses it to explain the intended platform/model pairing, select an installed tested quant, apply fork-specific defaults, and warn before launch when the user deviates. The Strix Halo Flash Next experiment uses this mechanism for its direct-I/O and combined MTP/ngram recipe.
 
-Server actions are enabled. Starting a server shows its generated command, suspends the TUI, runs the named container in the foreground, and removes that container after Ctrl+C.
+In the Textual interface, server actions are enabled. Starting a server shows its generated command, suspends the TUI, runs the named container in the foreground, and removes that container after Ctrl+C. The reserved CLI server commands described above do not yet start or manage servers.
 
 ## Model behavior
 
@@ -139,6 +170,7 @@ ai_toolbox_cockpit/
 │   ├── toolboxes.json         # platforms, full OCI refs, container names, capabilities
 │   └── models.json            # four backend-specific model/bundle schemas
 ├── catalog/                   # typed loading and cross-reference validation
+├── cli/                       # explicit command grammar, dispatch, and text/JSON renderers
 ├── runtime/                   # engines, Toolbx/Distrobox, registry, process lifecycle
 ├── views/                     # unified Toolboxes, Server Mode, and Models shells
 └── backends/
@@ -157,8 +189,6 @@ Important boundaries:
 - API keys are entered at launch time and are not persisted.
 
 The complete schema rules and backend addition sequence are in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md). The one-backend-at-a-time hardware test procedure is in [`docs/REMOTE_VALIDATION.md`](docs/REMOTE_VALIDATION.md).
-
-The complete schema and extension contract are in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
 
 ## Milestones
 

--- a/ai_toolbox_cockpit/__init__.py
+++ b/ai_toolbox_cockpit/__init__.py
@@ -1,4 +1,10 @@
 """AI Toolbox Cockpit."""
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+
+try:
+    __version__ = version("ai-toolbox-cockpit")
+except PackageNotFoundError:
+    __version__ = "0.0.0+source"
 

--- a/ai_toolbox_cockpit/cli/__init__.py
+++ b/ai_toolbox_cockpit/cli/__init__.py
@@ -1,0 +1,54 @@
+"""Public command-line entry point for AI Toolbox Cockpit."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Sequence
+from typing import TextIO
+
+from .contracts import CliParseError, CommandError, EXIT_FAILURE, EXIT_INVALID_ARGUMENTS
+from .dispatch import dispatch
+from .parser import output_requested, parse_invocation
+from .registry import command_for_path
+from .renderers import render_error, render_result
+
+
+def run_cli(args: Sequence[str], stdout: TextIO, stderr: TextIO) -> int | None:
+    if not args:
+        return None
+    output = output_requested(args)
+    try:
+        parsed = parse_invocation(args)
+    except CliParseError as error:
+        render_error(
+            CommandError(code="invalid_arguments", message=str(error), exit_code=EXIT_INVALID_ARGUMENTS),
+            (),
+            output,
+            stderr,
+        )
+        return EXIT_INVALID_ARGUMENTS
+
+    try:
+        outcome = dispatch(parsed.invocation)
+    except Exception:
+        render_error(
+            CommandError(
+                code="internal_error",
+                message="An unexpected error occurred.",
+                exit_code=EXIT_FAILURE,
+            ),
+            parsed.invocation.command,
+            parsed.output,
+            stderr,
+        )
+        return EXIT_FAILURE
+    command = command_for_path(parsed.invocation.command)
+    if isinstance(outcome, CommandError):
+        render_error(outcome, parsed.invocation.command, parsed.output, stderr)
+        return outcome.exit_code
+    render_result(outcome, command, parsed.output, stdout)
+    return outcome.exit_code
+
+
+def run_from_argv(argv: Sequence[str] | None = None) -> int | None:
+    return run_cli(sys.argv[1:] if argv is None else argv, sys.stdout, sys.stderr)

--- a/ai_toolbox_cockpit/cli/commands/__init__.py
+++ b/ai_toolbox_cockpit/cli/commands/__init__.py
@@ -1,0 +1,1 @@
+"""CLI command handlers."""

--- a/ai_toolbox_cockpit/cli/commands/info.py
+++ b/ai_toolbox_cockpit/cli/commands/info.py
@@ -1,0 +1,160 @@
+"""Static catalogue report command."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+
+from ...catalog import CatalogError, ModelBackendCatalog, Toolbox, load_model_catalog, load_toolbox_catalog
+from ...settings import get_backend_settings, load_active_platform
+from ...updates import installed_version
+from ..contracts import CLI_SCHEMA_VERSION, CommandError, CommandResult, EXIT_UNAVAILABLE, Invocation
+
+
+def handle_info(invocation: Invocation) -> CommandResult | CommandError:
+    from ..registry import command_capabilities
+
+    try:
+        return CommandResult(
+            data=build_info_report(
+                full=bool(invocation.arguments["full"]),
+                capabilities=command_capabilities(),
+            )
+        )
+    except (CatalogError, OSError, ValueError) as error:
+        return CommandError(
+            code="catalog_error",
+            message=str(error),
+            exit_code=EXIT_UNAVAILABLE,
+        )
+
+
+def build_info_report(full: bool, capabilities: Mapping[str, Any]) -> dict[str, Any]:
+    toolbox_catalog = load_toolbox_catalog()
+    model_catalog = load_model_catalog()
+    fallback_platform = toolbox_catalog.platforms[0].id if toolbox_catalog.platforms else ""
+    models_dir = get_backend_settings("llama_cpp").get("models_dir")
+
+    catalog: dict[str, Any] = {
+        "toolbox_schema_version": toolbox_catalog.schema_version,
+        "model_schema_version": model_catalog.schema_version,
+        "platforms": [
+            {
+                "id": platform.id,
+                "name": platform.name,
+                "description": platform.description,
+                "toolbox_ids": list(platform.toolbox_ids),
+                "defaults": platform.defaults,
+            }
+            for platform in toolbox_catalog.platforms
+        ],
+        "toolboxes": [
+            _toolbox_report(toolbox, full)
+            for toolbox in sorted(toolbox_catalog.toolboxes.values(), key=lambda item: item.id)
+        ],
+        "backends": {
+            backend_id: _backend_report(backend, full)
+            for backend_id, backend in sorted(model_catalog.backends.items())
+        },
+    }
+    if full:
+        catalog["runtime_profiles"] = {
+            profile_id: {"engine_args": list(profile.engine_args)}
+            for profile_id, profile in sorted(toolbox_catalog.runtime_profiles.items())
+        }
+
+    return {
+        "full": full,
+        "application": {
+            "name": "ai-toolbox-cockpit",
+            "version": installed_version(),
+        },
+        "configuration": {
+            "active_platform": load_active_platform(fallback_platform),
+            "llama_cpp_models_dir": models_dir if isinstance(models_dir, str) and models_dir else "~/models",
+        },
+        "capabilities": capabilities,
+        "catalog": catalog,
+    }
+
+
+def render_info_text(data: Mapping[str, Any]) -> str:
+    application = data["application"]
+    configuration = data["configuration"]
+    catalog = data["catalog"]
+    lines = [
+        f"AI Toolbox Cockpit {application['version']}",
+        f"CLI schema: {CLI_SCHEMA_VERSION}",
+        f"Active platform: {configuration['active_platform']}",
+        f"llama.cpp models directory: {configuration['llama_cpp_models_dir']}",
+        "",
+        "Platforms:",
+    ]
+    lines.extend(
+        f"- {platform['id']}: {platform['name']} ({len(platform['toolbox_ids'])} toolboxes)"
+        for platform in catalog["platforms"]
+    )
+    lines.extend(("", "Backends:"))
+    for backend in catalog["backends"].values():
+        lines.append(f"- {backend['id']} [{backend['kind']}]: {backend['entry_count']} {backend['entries_key']}")
+        for model in backend[backend["entries_key"]]:
+            details = " — ".join(
+                str(value)
+                for key, value in model.items()
+                if key in {"name", "repo", "filename"} and value
+            )
+            lines.append(f"  - {model['id']}{f': {details}' if details else ''}")
+    lines.extend(("", "Toolboxes:"))
+    lines.extend(
+        f"- {toolbox['id']} [{toolbox['backend']}]: {toolbox['image']}"
+        for toolbox in catalog["toolboxes"]
+    )
+    if data["full"]:
+        lines.extend(("", "Full static catalogue:"))
+        lines.append(json.dumps(catalog, indent=2, sort_keys=True))
+    return "\n".join(lines) + "\n"
+
+
+def _toolbox_report(toolbox: Toolbox, full: bool) -> dict[str, Any]:
+    report: dict[str, Any] = {
+        "id": toolbox.id,
+        "backend": toolbox.backend,
+        "name": toolbox.name,
+        "container_name": toolbox.container_name,
+        "group": toolbox.group,
+        "image": toolbox.image,
+        "channel": toolbox.channel,
+        "maturity": toolbox.maturity,
+        "description": toolbox.description,
+        "runtime_profile": toolbox.runtime_profile,
+        "features": toolbox.features,
+        "server_binary": toolbox.server_binary,
+        "supports_load_mode": toolbox.supports_load_mode,
+    }
+    if full:
+        report["backend_config"] = toolbox.backend_config or {}
+    return report
+
+
+def _backend_report(backend: ModelBackendCatalog, full: bool) -> dict[str, Any]:
+    report: dict[str, Any] = {
+        "id": backend.id,
+        "kind": backend.kind,
+        "entries_key": backend.entries_key,
+        "storage": backend.storage,
+        "entry_count": len(backend.entries),
+        backend.entries_key: [_entry_report(entry, full) for entry in backend.entries],
+    }
+    if full:
+        report["config"] = backend.config
+    return report
+
+
+def _entry_report(entry: dict[str, Any], full: bool) -> dict[str, Any]:
+    if full:
+        return dict(entry)
+    return {
+        key: value
+        for key, value in entry.items()
+        if value is None or isinstance(value, (str, int, float, bool))
+    }

--- a/ai_toolbox_cockpit/cli/commands/server.py
+++ b/ai_toolbox_cockpit/cli/commands/server.py
@@ -1,0 +1,17 @@
+"""Reserved server command handlers.
+
+Runtime lifecycle, container labels, and event streaming are intentionally
+deferred until they can be validated on remote GPU systems.
+"""
+
+from __future__ import annotations
+
+from ..contracts import CommandError, EXIT_UNAVAILABLE, Invocation
+
+
+def handle_reserved_server_command(invocation: Invocation) -> CommandError:
+    return CommandError(
+        code="not_implemented",
+        message=f"{' '.join(invocation.command)} is not implemented yet. No runtime action was taken.",
+        exit_code=EXIT_UNAVAILABLE,
+    )

--- a/ai_toolbox_cockpit/cli/contracts.py
+++ b/ai_toolbox_cockpit/cli/contracts.py
@@ -1,0 +1,59 @@
+"""Types shared by CLI parsing, command handlers, and renderers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any, Mapping
+
+
+CLI_SCHEMA_VERSION = 2
+EXIT_FAILURE = 1
+EXIT_INVALID_ARGUMENTS = 2
+EXIT_UNAVAILABLE = 3
+
+
+class OutputFormat(StrEnum):
+    TEXT = "text"
+    JSON = "json"
+
+
+@dataclass(frozen=True)
+class Invocation:
+    command: tuple[str, ...]
+    arguments: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class ParsedInvocation:
+    invocation: Invocation
+    output: OutputFormat
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    data: Mapping[str, Any]
+    warnings: tuple[str, ...] = ()
+    exit_code: int = 0
+
+
+@dataclass(frozen=True)
+class CommandError:
+    code: str
+    message: str
+    exit_code: int
+    details: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class CommandEvent:
+    kind: str
+    sequence: int
+    data: Mapping[str, Any]
+    run_id: str = ""
+    session_id: str = ""
+    stream: str = "stdout"
+
+
+class CliParseError(ValueError):
+    """An argument error that can be rendered using the selected output format."""

--- a/ai_toolbox_cockpit/cli/dispatch.py
+++ b/ai_toolbox_cockpit/cli/dispatch.py
@@ -1,0 +1,10 @@
+"""Dispatch parsed CLI invocations to explicitly registered handlers."""
+
+from __future__ import annotations
+
+from .contracts import CommandError, CommandResult, Invocation
+from .registry import command_for_path
+
+
+def dispatch(invocation: Invocation) -> CommandResult | CommandError:
+    return command_for_path(invocation.command).handler(invocation)

--- a/ai_toolbox_cockpit/cli/parser.py
+++ b/ai_toolbox_cockpit/cli/parser.py
@@ -1,0 +1,128 @@
+"""Build and parse the CLI grammar declared in the command registry."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+from typing import Any
+
+from .contracts import CliParseError, Invocation, OutputFormat, ParsedInvocation
+from .registry import COMMANDS, OUTPUT_ARGUMENT, CommandSpec, command_for_path
+
+
+class _ArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        raise CliParseError(message)
+
+
+def normalize_legacy_args(args: Sequence[str]) -> list[str]:
+    """Map the explicitly supported legacy command spellings to canonical syntax."""
+    normalized: list[str] = []
+    command_seen = False
+    output_value_expected = False
+    for argument in args:
+        if output_value_expected:
+            normalized.append(argument)
+            output_value_expected = False
+            continue
+        if argument == "-help":
+            normalized.append("--help")
+        elif argument == "--output":
+            normalized.append(argument)
+            output_value_expected = True
+        elif argument.startswith("--output="):
+            normalized.append(argument)
+        elif not command_seen and argument == "-info":
+            normalized.append("info")
+            command_seen = True
+        elif not command_seen and argument == "-fullinfo":
+            normalized.extend(("info", "--full"))
+            command_seen = True
+        else:
+            normalized.append(argument)
+            if not argument.startswith("-"):
+                command_seen = True
+    return normalized
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = _ArgumentParser(
+        prog="ai-toolbox-cockpit",
+        description="Inspect AI Toolbox Cockpit and manage supported server workflows.",
+    )
+    _add_output_argument(parser, suppress_default=False)
+    nodes: dict[tuple[str, ...], argparse.ArgumentParser] = {(): parser}
+    subparsers: dict[tuple[str, ...], Any] = {}
+
+    for command in sorted(COMMANDS, key=lambda item: item.path):
+        for index, part in enumerate(command.path):
+            parent_path = command.path[:index]
+            path = command.path[: index + 1]
+            if path in nodes:
+                continue
+            parent = nodes[parent_path]
+            group = subparsers.get(parent_path)
+            if group is None:
+                group = parent.add_subparsers(dest=f"_command_{index}", required=True)
+                subparsers[parent_path] = group
+            child = group.add_parser(part, help=command.help if path == command.path else None)
+            _add_output_argument(child, suppress_default=True)
+            nodes[path] = child
+
+        command_parser = nodes[command.path]
+        _add_command_arguments(command_parser, command)
+        command_parser.set_defaults(_command_path=command.path)
+    return parser
+
+
+def parse_invocation(args: Sequence[str]) -> ParsedInvocation:
+    namespace = build_parser().parse_args(normalize_legacy_args(args))
+    values = vars(namespace)
+    path = values.get("_command_path")
+    if path is None:
+        raise CliParseError("a command is required")
+    command = command_for_path(path)
+    arguments = {
+        key: value
+        for key, value in values.items()
+        if not key.startswith("_command_") and key not in {"_command_path", "output"}
+    }
+    return ParsedInvocation(
+        invocation=Invocation(command=command.path, arguments=arguments),
+        output=OutputFormat(values["output"]),
+    )
+
+
+def output_requested(args: Sequence[str]) -> OutputFormat:
+    """Infer a requested output format before a parser error can be rendered."""
+    normalized = normalize_legacy_args(args)
+    requested = OutputFormat.TEXT
+    for index, argument in enumerate(normalized):
+        if argument.startswith("--output="):
+            value = argument.split("=", 1)[1]
+        elif argument == "--output" and index + 1 < len(normalized):
+            value = normalized[index + 1]
+        else:
+            continue
+        try:
+            requested = OutputFormat(value)
+        except ValueError:
+            return OutputFormat.TEXT
+    return requested
+
+
+def _add_output_argument(parser: argparse.ArgumentParser, *, suppress_default: bool) -> None:
+    OUTPUT_ARGUMENT.add_to(parser, suppress_default=suppress_default)
+
+
+def _add_command_arguments(parser: argparse.ArgumentParser, command: CommandSpec) -> None:
+    groups: dict[str, Any] = {}
+    for argument in command.arguments:
+        if argument.group is None:
+            argument.add_to(parser)
+            continue
+        group = groups.get(argument.group)
+        if group is None:
+            group = parser.add_mutually_exclusive_group(required=argument.group_required)
+            groups[argument.group] = group
+        argument.add_to(group)

--- a/ai_toolbox_cockpit/cli/registry.py
+++ b/ai_toolbox_cockpit/cli/registry.py
@@ -1,0 +1,160 @@
+"""The explicit, single source of truth for CLI commands and arguments."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping
+
+from .commands.info import handle_info, render_info_text
+from .commands.server import handle_reserved_server_command
+from .contracts import CommandError, CommandResult, Invocation
+
+
+CommandHandler = Callable[[Invocation], CommandResult | CommandError]
+TextPresenter = Callable[[Mapping[str, Any]], str]
+_DEFAULT_UNSET = object()
+
+
+@dataclass(frozen=True)
+class ArgumentSpec:
+    flags: tuple[str, ...]
+    help: str
+    action: str | type[argparse.Action] | None = None
+    choices: tuple[str, ...] | None = None
+    value_type: type | None = None
+    required: bool = False
+    default: Any = _DEFAULT_UNSET
+    group: str | None = None
+    group_required: bool = False
+
+    def add_to(self, target: Any, *, suppress_default: bool = False) -> None:
+        kwargs: dict[str, Any] = {"help": self.help}
+        if self.action is not None:
+            kwargs["action"] = self.action
+        if self.choices is not None:
+            kwargs["choices"] = self.choices
+        if self.value_type is not None:
+            kwargs["type"] = self.value_type
+        if self.required:
+            kwargs["required"] = True
+        if suppress_default:
+            kwargs["default"] = argparse.SUPPRESS
+        elif self.default is not _DEFAULT_UNSET:
+            kwargs["default"] = self.default
+        target.add_argument(*self.flags, **kwargs)
+
+
+@dataclass(frozen=True)
+class CommandSpec:
+    path: tuple[str, ...]
+    help: str
+    state: str
+    handler: CommandHandler
+    arguments: tuple[ArgumentSpec, ...] = ()
+    text_presenter: TextPresenter | None = None
+
+
+OUTPUT_ARGUMENT = ArgumentSpec(
+    flags=("--output",),
+    choices=("text", "json"),
+    default="text",
+    help="Write text (default) or JSON output.",
+)
+
+LLAMA_CPP_LAUNCH_ARGUMENTS = (
+    ArgumentSpec(("--model",), required=True, help="Local GGUF model path, or auto."),
+    ArgumentSpec(("--platform",), help="Platform catalogue ID."),
+    ArgumentSpec(("--toolbox",), help="llama.cpp toolbox catalogue ID."),
+    ArgumentSpec(("--engine",), choices=("podman", "docker"), help="Container engine."),
+    ArgumentSpec(("--host",), help="Server bind address."),
+    ArgumentSpec(("--port",), value_type=int, help="Server port."),
+    ArgumentSpec(("--context-size",), value_type=int, help="Context size."),
+    ArgumentSpec(("--gpu-layers",), value_type=int, help="GPU layers."),
+    ArgumentSpec(("--load-mode",), choices=("none", "mmap", "dio"), help="Model load mode."),
+    ArgumentSpec(
+        ("--flash-attention",),
+        action=argparse.BooleanOptionalAction,
+        help="Enable or disable Flash Attention.",
+    ),
+    ArgumentSpec(("--kv-cache-type",), help="KV-cache quantization type."),
+    ArgumentSpec(("--batch-size",), value_type=int, help="Logical batch size."),
+    ArgumentSpec(("--ubatch-size",), value_type=int, help="Physical micro-batch size."),
+    ArgumentSpec(("--parallel-sequences",), value_type=int, help="Parallel sequence count."),
+)
+
+SERVER_BACKENDS = ("llama-cpp", "ds4", "vllm", "comfyui")
+
+COMMANDS = (
+    CommandSpec(
+        path=("info",),
+        help="Print application and static catalogue information.",
+        state="supported",
+        handler=handle_info,
+        arguments=(ArgumentSpec(("--full",), action="store_true", help="Include all static catalogue fields."),),
+        text_presenter=render_info_text,
+    ),
+    CommandSpec(
+        path=("server", "plan", "llama-cpp"),
+        help="Preview a llama.cpp launch configuration (reserved).",
+        state="reserved",
+        handler=handle_reserved_server_command,
+        arguments=LLAMA_CPP_LAUNCH_ARGUMENTS,
+    ),
+    CommandSpec(
+        path=("server", "start", "llama-cpp"),
+        help="Start llama.cpp in the foreground (reserved).",
+        state="reserved",
+        handler=handle_reserved_server_command,
+        arguments=LLAMA_CPP_LAUNCH_ARGUMENTS,
+    ),
+    CommandSpec(
+        path=("server", "status"),
+        help="Show Cockpit-managed servers (reserved).",
+        state="reserved",
+        handler=handle_reserved_server_command,
+        arguments=(
+            ArgumentSpec(("--backend",), choices=SERVER_BACKENDS, help="Filter by backend."),
+            ArgumentSpec(("--session",), help="Filter by session ID."),
+        ),
+    ),
+    CommandSpec(
+        path=("server", "logs"),
+        help="Show managed server logs (reserved).",
+        state="reserved",
+        handler=handle_reserved_server_command,
+        arguments=(
+            ArgumentSpec(("--run",), required=True, help="Managed server run ID."),
+            ArgumentSpec(("--follow",), action="store_true", help="Follow log output."),
+        ),
+    ),
+    CommandSpec(
+        path=("server", "stop"),
+        help="Stop managed servers (reserved).",
+        state="reserved",
+        handler=handle_reserved_server_command,
+        arguments=(
+            ArgumentSpec(("--run",), group="target", group_required=True, help="Managed server run ID."),
+            ArgumentSpec(("--session",), group="target", group_required=True, help="Managed server session ID."),
+            ArgumentSpec(("--all",), action="store_true", group="target", group_required=True, help="Target all Cockpit-managed servers."),
+            ArgumentSpec(("--yes",), action="store_true", help="Confirm a non-interactive bulk stop."),
+        ),
+    ),
+)
+
+
+def command_for_path(path: tuple[str, ...]) -> CommandSpec:
+    for command in COMMANDS:
+        if command.path == path:
+            return command
+    raise KeyError(path)
+
+
+def command_capabilities() -> dict[str, Any]:
+    capabilities: dict[str, Any] = {}
+    for command in COMMANDS:
+        current = capabilities
+        for part in command.path[:-1]:
+            current = current.setdefault(part, {})
+        current[command.path[-1]] = command.state
+    return capabilities

--- a/ai_toolbox_cockpit/cli/renderers.py
+++ b/ai_toolbox_cockpit/cli/renderers.py
@@ -1,0 +1,81 @@
+"""Output encoders for completed CLI commands and future event streams."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from typing import TextIO
+
+from .contracts import CLI_SCHEMA_VERSION, CommandError, CommandEvent, CommandResult, OutputFormat
+from .registry import CommandSpec
+
+
+def render_result(result: CommandResult, command: CommandSpec, output: OutputFormat, stdout: TextIO) -> None:
+    if output is OutputFormat.JSON:
+        _write_json(
+            stdout,
+            {
+                "schema_version": CLI_SCHEMA_VERSION,
+                "command": list(command.path),
+                "ok": True,
+                "data": result.data,
+                "warnings": list(result.warnings),
+            },
+        )
+        return
+    if command.text_presenter is not None:
+        stdout.write(command.text_presenter(result.data))
+    else:
+        stdout.write("Command completed.\n")
+
+
+def render_error(error: CommandError, command: tuple[str, ...], output: OutputFormat, stderr: TextIO) -> None:
+    if output is OutputFormat.JSON:
+        _write_json(
+            stderr,
+            {
+                "schema_version": CLI_SCHEMA_VERSION,
+                "command": list(command),
+                "ok": False,
+                "error": {
+                    "code": error.code,
+                    "message": error.message,
+                    "details": error.details,
+                },
+            },
+        )
+        return
+    stderr.write(f"Error: {error.message}\n")
+
+
+def render_events(events: Iterable[CommandEvent], command: tuple[str, ...], output: OutputFormat, stdout: TextIO, stderr: TextIO) -> None:
+    """Render the future foreground server event protocol without owning lifecycle."""
+    for event in events:
+        if output is OutputFormat.JSON:
+            _write_json_line(
+                stdout,
+                {
+                    "schema_version": CLI_SCHEMA_VERSION,
+                    "command": list(command),
+                    "event": event.kind,
+                    "sequence": event.sequence,
+                    "run_id": event.run_id,
+                    "session_id": event.session_id,
+                    "stream": event.stream,
+                    "data": event.data,
+                },
+            )
+            continue
+        destination = stderr if event.stream == "stderr" else stdout
+        message = event.data.get("message", "")
+        destination.write(f"{message}\n" if message else "")
+
+
+def _write_json(stream: TextIO, payload: object) -> None:
+    json.dump(payload, stream, indent=2, sort_keys=True)
+    stream.write("\n")
+
+
+def _write_json_line(stream: TextIO, payload: object) -> None:
+    json.dump(payload, stream, sort_keys=True)
+    stream.write("\n")

--- a/ai_toolbox_cockpit/main.py
+++ b/ai_toolbox_cockpit/main.py
@@ -1,18 +1,30 @@
 import os
 import sys
 
-from .app import AiToolboxCockpitApp
+from .cli import run_from_argv
 from .updates import RELAUNCH_AFTER_UPDATE
 
 
-def cli_main() -> None:
-    result = AiToolboxCockpitApp().run()
+def _load_app_class():
+    from .app import AiToolboxCockpitApp
+
+    return AiToolboxCockpitApp
+
+
+def _run_tui() -> int:
+    result = _load_app_class()().run()
     if result == RELAUNCH_AFTER_UPDATE:
         os.execv(
             sys.executable,
             [sys.executable, "-m", "ai_toolbox_cockpit.main"],
         )
+    return 0
+
+
+def cli_main(argv: list[str] | None = None) -> int:
+    result = run_from_argv(argv)
+    return _run_tui() if result is None else result
 
 
 if __name__ == "__main__":
-    cli_main()
+    raise SystemExit(cli_main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,215 @@
+import io
+import json
+from contextlib import redirect_stderr, redirect_stdout
+from unittest import TestCase
+from unittest.mock import patch
+
+from ai_toolbox_cockpit.catalog import CatalogError
+from ai_toolbox_cockpit.cli.contracts import CommandEvent, OutputFormat
+from ai_toolbox_cockpit.cli.parser import parse_invocation
+from ai_toolbox_cockpit.cli.renderers import render_events
+from ai_toolbox_cockpit.main import cli_main
+
+
+class StaticCliTests(TestCase):
+    def invoke(self, *args: str) -> tuple[int, str, str]:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            result = cli_main(list(args))
+        return result, stdout.getvalue(), stderr.getvalue()
+
+    def test_info_text_is_human_readable(self) -> None:
+        result, stdout, stderr = self.invoke("info")
+
+        self.assertEqual(result, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("AI Toolbox Cockpit", stdout)
+        self.assertIn("Platforms:", stdout)
+        self.assertIn("Backends:", stdout)
+        self.assertIn("Toolboxes:", stdout)
+
+    def test_absent_boolean_flag_uses_false_default(self) -> None:
+        parsed = parse_invocation(("info",))
+
+        self.assertIs(parsed.invocation.arguments["full"], False)
+
+    def test_info_does_not_start_the_textual_application(self) -> None:
+        with patch("ai_toolbox_cockpit.main._load_app_class") as app_class:
+            result, _, _ = self.invoke("info")
+
+        self.assertEqual(result, 0)
+        app_class.assert_not_called()
+
+    def test_info_does_not_start_subprocesses(self) -> None:
+        with patch("subprocess.Popen") as process, patch("subprocess.run") as run:
+            result, _, _ = self.invoke("info")
+
+        self.assertEqual(result, 0)
+        process.assert_not_called()
+        run.assert_not_called()
+
+    def test_info_json_returns_catalog_summary_without_starting_the_tui(self) -> None:
+        result, stdout, stderr = self.invoke("info", "--output", "json")
+
+        payload = json.loads(stdout)
+        self.assertEqual(result, 0)
+        self.assertEqual(stderr, "")
+        self.assertEqual(payload["schema_version"], 2)
+        self.assertEqual(payload["command"], ["info"])
+        self.assertTrue(payload["ok"])
+        self.assertIn("application", payload["data"])
+        self.assertIn("catalog", payload["data"])
+        self.assertIn("platforms", payload["data"]["catalog"])
+        self.assertIn("backends", payload["data"]["catalog"])
+        self.assertTrue(payload["data"]["catalog"]["backends"]["llama_cpp"]["models"])
+        self.assertTrue(payload["data"]["catalog"]["backends"]["comfyui"]["bundles"])
+
+    def test_fullinfo_alias_returns_full_catalog_as_json(self) -> None:
+        result, stdout, stderr = self.invoke("-fullinfo", "--output", "json")
+
+        payload = json.loads(stdout)
+        data = payload["data"]
+        llama_cpp = data["catalog"]["backends"]["llama_cpp"]
+        self.assertEqual(result, 0)
+        self.assertEqual(stderr, "")
+        self.assertTrue(data["full"])
+        self.assertIn("config", llama_cpp)
+        self.assertIn("runtime_profiles", data["catalog"])
+        self.assertIn("backend_config", data["catalog"]["toolboxes"][0])
+
+    def test_output_is_accepted_before_the_command(self) -> None:
+        result, stdout, stderr = self.invoke("--output", "json", "info")
+
+        self.assertEqual(result, 0)
+        self.assertEqual(stderr, "")
+        self.assertTrue(json.loads(stdout)["ok"])
+
+    def test_legacy_info_alias_is_accepted_after_global_output(self) -> None:
+        result, stdout, stderr = self.invoke("--output", "json", "-info")
+
+        self.assertEqual(result, 0)
+        self.assertEqual(stderr, "")
+        self.assertTrue(json.loads(stdout)["ok"])
+
+    def test_removed_json_alias_is_reported_as_an_argument_error(self) -> None:
+        result, stdout, stderr = self.invoke("info", "--json")
+
+        self.assertEqual(result, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn("unrecognized arguments: --json", stderr)
+
+    def test_invalid_arguments_use_the_json_error_envelope_when_requested(self) -> None:
+        result, stdout, stderr = self.invoke("info", "--output", "json", "--unknown")
+
+        payload = json.loads(stderr)
+        self.assertEqual(result, 2)
+        self.assertEqual(stdout, "")
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["error"]["code"], "invalid_arguments")
+
+    def test_last_output_option_selects_parse_error_format(self) -> None:
+        result, stdout, stderr = self.invoke("info", "--output", "json", "--output", "text", "--unknown")
+
+        self.assertEqual(result, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn("unrecognized arguments: --unknown", stderr)
+
+    def test_undocumented_long_info_alias_is_rejected(self) -> None:
+        result, stdout, stderr = self.invoke("info", "--info")
+
+        self.assertEqual(result, 2)
+        self.assertEqual(stdout, "")
+        self.assertIn("unrecognized arguments: --info", stderr)
+
+    def test_classic_help_aliases_show_usage(self) -> None:
+        for argument in ("-h", "-help"):
+            with self.subTest(argument=argument):
+                with self.assertRaises(SystemExit) as exited:
+                    self.invoke(argument)
+
+                self.assertEqual(exited.exception.code, 0)
+
+    def test_server_commands_are_reserved_without_starting_a_container(self) -> None:
+        result, stdout, stderr = self.invoke(
+            "server",
+            "start",
+            "llama-cpp",
+            "--model",
+            "model.gguf",
+            "--context-size",
+            "4096",
+            "--output",
+            "json",
+        )
+
+        self.assertEqual(result, 3)
+        self.assertEqual(stdout, "")
+        payload = json.loads(stderr)
+        self.assertEqual(payload["error"]["code"], "not_implemented")
+        self.assertEqual(payload["command"], ["server", "start", "llama-cpp"])
+
+    def test_server_stop_accepts_each_target_selector(self) -> None:
+        for selector in (("--run", "run-1"), ("--session", "session-1"), ("--all",)):
+            with self.subTest(selector=selector):
+                result, stdout, stderr = self.invoke("server", "stop", *selector, "--output", "json")
+
+                self.assertEqual(result, 3)
+                self.assertEqual(stdout, "")
+                self.assertEqual(json.loads(stderr)["error"]["code"], "not_implemented")
+
+    def test_catalog_error_uses_the_json_error_envelope(self) -> None:
+        with patch(
+            "ai_toolbox_cockpit.cli.commands.info.load_toolbox_catalog",
+            side_effect=CatalogError("invalid catalogue"),
+        ):
+            result, stdout, stderr = self.invoke("info", "--output", "json")
+
+        payload = json.loads(stderr)
+        self.assertEqual(result, 3)
+        self.assertEqual(stdout, "")
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["error"]["code"], "catalog_error")
+        self.assertEqual(payload["error"]["message"], "invalid catalogue")
+
+    def test_unexpected_command_error_uses_the_json_error_envelope(self) -> None:
+        with patch("ai_toolbox_cockpit.cli.dispatch", side_effect=RuntimeError):
+            result, stdout, stderr = self.invoke("info", "--output", "json")
+
+        payload = json.loads(stderr)
+        self.assertEqual(result, 1)
+        self.assertEqual(stdout, "")
+        self.assertEqual(payload["error"]["code"], "internal_error")
+
+    def test_future_json_events_are_json_lines(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        render_events(
+            [
+                CommandEvent(
+                    kind="started",
+                    sequence=1,
+                    data={"message": "Starting"},
+                    run_id="run-1",
+                    session_id="session-1",
+                ),
+                CommandEvent(
+                    kind="output",
+                    sequence=2,
+                    data={"message": "Ready"},
+                    run_id="run-1",
+                    session_id="session-1",
+                ),
+            ],
+            ("server", "start", "llama-cpp"),
+            OutputFormat.JSON,
+            stdout,
+            stderr,
+        )
+
+        lines = stdout.getvalue().splitlines()
+        self.assertEqual(len(lines), 2)
+        self.assertEqual(json.loads(lines[0])["event"], "started")
+        self.assertEqual(json.loads(lines[1])["event"], "output")
+        self.assertEqual(stderr.getvalue(), "")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,12 +9,12 @@ from ai_toolbox_cockpit.updates import RELAUNCH_AFTER_UPDATE
 class MainTests(TestCase):
     def test_successful_application_update_relaunches_current_environment(self) -> None:
         with (
-            patch("ai_toolbox_cockpit.main.AiToolboxCockpitApp") as app_class,
+            patch("ai_toolbox_cockpit.main._load_app_class") as app_class,
             patch("ai_toolbox_cockpit.main.os.execv") as execv,
         ):
-            app_class.return_value.run.return_value = RELAUNCH_AFTER_UPDATE
+            app_class.return_value.return_value.run.return_value = RELAUNCH_AFTER_UPDATE
 
-            cli_main()
+            cli_main([])
 
         execv.assert_called_once_with(
             sys.executable,
@@ -23,11 +23,11 @@ class MainTests(TestCase):
 
     def test_normal_exit_does_not_relaunch(self) -> None:
         with (
-            patch("ai_toolbox_cockpit.main.AiToolboxCockpitApp") as app_class,
+            patch("ai_toolbox_cockpit.main._load_app_class") as app_class,
             patch("ai_toolbox_cockpit.main.os.execv") as execv,
         ):
-            app_class.return_value.run.return_value = None
+            app_class.return_value.return_value.run.return_value = None
 
-            cli_main()
+            cli_main([])
 
         execv.assert_not_called()


### PR DESCRIPTION

The goal was to make the CLI easy to extend without duplicating application logic or spreading command handling across unrelated code. Command syntax, arguments, help, capabilities, and handlers are described through one explicit registry. Text and JSON output are handled separately from command logic, so future commands can reuse the same execution path and add formats without rewriting their core behaviour.

The first working command is info. It exposes static application and catalogue data in text or JSON, including a compact summary and a full catalogue export. It does not start the TUI, containers, network requests, GPU workloads, or model runtimes. JSON responses use a versioned schema envelope so that pipelines can detect incompatible changes if the format has to evolve later.

I also reserved the server command namespace, but those commands intentionally return not_implemented for now. Before runtime server management is added, the backend/runtime side needs a unified registration and resource-management path. That will make it possible to start, inspect, find, and stop Cockpit-managed servers without keeping the main application running.

This can be merged as a foundation. 
Existing TUI behaviour and container lifecycle are unchanged, and CLI work can continue independently while the runtime integration is designed and tested on remote GPU hosts.